### PR TITLE
support Minecraft 1.21.11 (jade)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ task curseforge(type: Exec) {
 		    --environments "Client,Server" \
 		    --loaders "Fabric" \
 		    --java-versions "Java 21" \
-		    --game-versions "1.21.6,1.21.7,1.21.8,1.21.9,1.21.10" \
+		    --game-versions "1.21.11" \
 		    --dependencies "fabric-api=required,jade=required"
 	"""
 }
@@ -125,7 +125,7 @@ modrinth {
 	versionType = "release"
 	changelog = "[v${project.version}](https://github.com/Aton-Kish/your-reputation/releases/tag/v" + java.net.URLEncoder.encode(project.version, "UTF-8") + ")"
 
-	gameVersions = ["1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10"]
+	gameVersions = ["1.21.11"]
 	loaders = ["fabric"]
 
 	dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,20 +7,20 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.21.10
-	yarn_mappings=1.21.10+build.2
-	loader_version=0.17.3
-	loom_version=1.12-SNAPSHOT
+	minecraft_version=1.21.11
+	yarn_mappings=1.21.11+build.6
+	loader_version=0.19.3
+	loom_version=1.14-SNAPSHOT
 
 # Mod Properties
-	mod_version=0.2.12+jade.1.21.10
+	mod_version=0.2.13+jade.1.21.11
 	mod_id=reputation
 	maven_group=atonkish.reputation
 	archives_base_name=your-reputation
 
 # Dependencies
-	fabric_version=0.136.0+1.21.10
-	jade_version=20.1.0+fabric
+	fabric_version=0.141.4+1.21.11
+	jade_version=21.1.6+fabric
 
 # Distribution platform
 	curseforge_id=1038051

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/atonkish/reputation/mixin/IronGolemEntityMixin.java
+++ b/src/main/java/atonkish/reputation/mixin/IronGolemEntityMixin.java
@@ -42,7 +42,7 @@ public abstract class IronGolemEntityMixin implements Angerable, IronGolemEntity
         this.setAttacker(null);
         this.setAngryAt(null);
         this.setTarget(null);
-        this.setAngerTime(0);
+        this.setAngerEndTime(Angerable.NO_ANGER_END_TIME);
         this.clearReports();
     }
 }

--- a/src/main/java/atonkish/reputation/provider/IronGolemProvider.java
+++ b/src/main/java/atonkish/reputation/provider/IronGolemProvider.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import com.google.common.cache.Cache;
 
+import net.minecraft.entity.LazyEntityReference;
 import net.minecraft.entity.passive.IronGolemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
@@ -42,9 +43,9 @@ public class IronGolemProvider implements IServerDataProvider<EntityAccessor> {
         IronGolemEntity golem = (IronGolemEntity) accessor.getEntity();
 
         @Nullable
-        UUID angryAt = golem.getAngryAt();
-        if (angryAt != null) {
-            data.put(IronGolemProvider.ANGRY_AT_KEY, ModNbtHelper.fromUuid(angryAt));
+        LazyEntityReference angryAtRef = golem.getAngryAt();
+        if (angryAtRef != null) {
+            data.put(IronGolemProvider.ANGRY_AT_KEY, ModNbtHelper.fromUuid(angryAtRef.getUuid()));
         }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,8 +22,8 @@
   "mixins": ["reputation.mixins.json"],
 
   "depends": {
-    "fabricloader": ">=0.16.10",
-    "minecraft": "~1.21.5",
+    "fabricloader": ">=0.19.3",
+    "minecraft": "~1.21.11",
     "java": ">=21",
     "fabric-api": "*",
     "jade": "*"


### PR DESCRIPTION
Hello! I used this mod in `1.21.10` but updated my modpack to `1.21.11` and saw that this mod does not have it yet. It was a minor fix, bumping up versions of a couple things, and changing the way iron golems are handeled as that got changed.

This would also close #66 #68

## Summary

- Bumps all dependencies for Minecraft 1.21.11
- Updates Gradle wrapper to 9.2.0 (required by loom 1.14.x)
- Fixes two breaking API changes in 1.21.11's `Angerable` interface

## Dependency changes

| Property | Before | After |
|---|---|---|
| `minecraft_version` | 1.21.10 | 1.21.11 |
| `yarn_mappings` | 1.21.10+build.2 | 1.21.11+build.6 |
| `loader_version` | 0.17.3 | 0.19.3 |
| `loom_version` | 1.12-SNAPSHOT | 1.14-SNAPSHOT |
| `fabric_version` | 0.136.0+1.21.10 | 0.141.4+1.21.11 |
| `jade_version` | 20.1.0+fabric | 21.1.6+fabric |
| `mod_version` | 0.2.12+jade.1.21.10 | 0.2.13+jade.1.21.11 |

## Iron golem anger API changes in 1.21.11

**`IronGolemEntityMixin`** — `setAngerTime(int)` was removed from `Angerable`; replaced with `setAngerEndTime(long)` using the new `Angerable.NO_ANGER_END_TIME` constant.

**`IronGolemProvider`** — `Angerable.getAngryAt()` now returns `LazyEntityReference` instead of `UUID`; added `.getUuid()` to extract the UUID from it.

## Test plan

- [x] Build passes (`./gradlew build`)
- [x] Iron golem anger indicator displays correctly in-game
- [x] Villager reputation tooltip displays correctly in-game